### PR TITLE
Make the color picker look better

### DIFF
--- a/src/Data/TagDefinition.cs
+++ b/src/Data/TagDefinition.cs
@@ -48,6 +48,12 @@ public class TagDefinition
         Color = new Color(0xFFFFFFFF);
     }
 
+    public TagDefinition(TagDefinition cloneFrom)
+    {
+        Name = cloneFrom.Name;
+        Color = cloneFrom.Color;
+    }
+
     public override bool Equals(object obj)
     {
         if (obj == this) return true;

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -371,6 +371,10 @@ public partial class MainWindow : Control
     {
         TagEditor.OnOk -= _EditTagOnOk;
         TagEditor.OnCancel -= _EditTagOnCancel;
+
+        TagDefinition originalTag = AvailableTags.SelectedTags.First();
+        originalTag.Name = TagEditor.ModifiedTag.Name;
+        originalTag.Color = TagEditor.ModifiedTag.Color;
         SaveTags();
     }
 

--- a/src/MainWindow.tscn
+++ b/src/MainWindow.tscn
@@ -52,6 +52,7 @@ _data = {
 }
 
 [node name="MainWindow" type="Control" node_paths=PackedStringArray("ConfigWindow", "ScanOverlay", "TagSearchText", "AvailableTags", "TagEditor", "FilterIncludeTags", "FilterExcludeTags", "FileSystemTree", "FilePathLabel", "AudioStreamPlayer", "PlaybackPosition", "VolumeSlider", "OpenButton", "AssignedTags")]
+custom_minimum_size = Vector2(0, 300)
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/src/TagUi/ColorPicker.tscn
+++ b/src/TagUi/ColorPicker.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=2 format=3 uid="uid://duxekhl7opalu"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7iwy5"]
+bg_color = Color(0.2, 0.2, 0.2, 0.78431374)
+
+[node name="ColorPicker" type="PopupPanel"]
+oversampling_override = 1.0
+size = Vector2i(306, 447)
+visible = true
+theme_override_styles/panel = SubResource("StyleBoxFlat_7iwy5")
+
+[node name="ColorPicker" type="ColorPicker" parent="."]
+offset_right = 306.0
+offset_bottom = 447.0
+edit_alpha = false
+edit_intensity = false
+picker_shape = 2
+sampler_visible = false
+color_modes_visible = false
+hex_visible = false

--- a/src/TagUi/TagEdit.tscn
+++ b/src/TagUi/TagEdit.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=2 format=3 uid="uid://dslev267kwqbq"]
+[gd_scene load_steps=3 format=3 uid="uid://dslev267kwqbq"]
 
 [ext_resource type="Script" uid="uid://dhxi4tkfvk0ip" path="res://TagUi/TagEditUi.cs" id="1_q4uoq"]
+[ext_resource type="PackedScene" uid="uid://duxekhl7opalu" path="res://TagUi/ColorPicker.tscn" id="2_r2j81"]
 
-[node name="TagEdit" type="Window" node_paths=PackedStringArray("TagName", "TagColor")]
+[node name="TagEdit" type="Window" node_paths=PackedStringArray("TagName", "CurrentColor", "ColorPickerButton", "ColorPickerPopup", "ColorPicker")]
 oversampling_override = 1.0
 title = "Edit Tag"
 initial_position = 2
@@ -13,7 +14,13 @@ unresizable = true
 popup_window = true
 script = ExtResource("1_q4uoq")
 TagName = NodePath("TagName")
-TagColor = NodePath("ColorPickerButton")
+CurrentColor = NodePath("ColorPickerButton/Color")
+ColorPickerButton = NodePath("ColorPickerButton")
+ColorPickerPopup = NodePath("ColorPicker")
+ColorPicker = NodePath("ColorPicker/ColorPicker")
+
+[node name="ColorPicker" parent="." instance=ExtResource("2_r2j81")]
+position = Vector2i(570, 60)
 
 [node name="TagNameLabel" type="Label" parent="."]
 offset_top = 8.0
@@ -33,12 +40,24 @@ offset_right = 42.0
 offset_bottom = 79.0
 text = "Color"
 
-[node name="ColorPickerButton" type="ColorPickerButton" parent="."]
+[node name="ColorPickerButton" type="Button" parent="."]
 offset_left = 80.0
 offset_top = 48.0
 offset_right = 192.0
 offset_bottom = 88.0
-color = Color(1, 1, 1, 1)
+
+[node name="Color" type="ColorRect" parent="ColorPickerButton"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 3.0
+offset_top = 3.0
+offset_right = -3.0
+offset_bottom = -3.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 1
 
 [node name="Ok" type="Button" parent="."]
 offset_left = 288.0
@@ -56,6 +75,8 @@ text = "Cancel"
 
 [connection signal="close_requested" from="." to="." method="_CancelClicked"]
 [connection signal="text_changed" from="TagName" to="." method="_TagNameChanged"]
-[connection signal="color_changed" from="ColorPickerButton" to="." method="_TagColorChanged"]
+[connection signal="pressed" from="ColorPickerButton" to="." method="_ColorButtonClicked"]
 [connection signal="pressed" from="Ok" to="." method="_OkClicked"]
 [connection signal="pressed" from="Cancel" to="." method="_CancelClicked"]
+
+[editable path="ColorPicker"]

--- a/src/TagUi/TagEditUi.cs
+++ b/src/TagUi/TagEditUi.cs
@@ -1,4 +1,5 @@
 using Godot;
+using Microsoft.VisualBasic;
 using System;
 
 public partial class TagEditUi : Window
@@ -6,7 +7,13 @@ public partial class TagEditUi : Window
     [Export]
     LineEdit TagName;
     [Export]
-    ColorPickerButton TagColor;
+    ColorRect CurrentColor;
+    [Export]
+    Button ColorPickerButton;
+    [Export]
+    PopupPanel ColorPickerPopup;
+    [Export]
+    ColorPicker ColorPicker;
 
     public event EventHandler OnCancel;
     public event EventHandler OnOk;
@@ -19,19 +26,21 @@ public partial class TagEditUi : Window
 
     public void AssignTag(TagDefinition tag)
     {
-        ModifiedTag = tag;
+        ModifiedTag = new TagDefinition(tag);
 
         TagName.Text = tag.Name;
-        TagColor.Color = tag.Color;
+        CurrentColor.Color = tag.Color;
+        ColorPicker.Color = tag.Color;
     }
 
     public override void _Ready()
     {
         TagName.Text = ModifiedTag.Name;
-        TagColor.Color = ModifiedTag.Color;
+        CurrentColor.Color = ModifiedTag.Color;
 
         TagName.TextChanged += _TagNameChanged;
-        TagColor.ColorChanged += _TagColorChanged;
+        ColorPicker.ColorChanged += _TagColorChanged;
+        ColorPickerPopup.VisibilityChanged += _ColorPickerVisibilityChanged;
     }
 
     private void _TagNameChanged(string newText)
@@ -42,6 +51,17 @@ public partial class TagEditUi : Window
     private void _TagColorChanged(Color color)
     {
         ModifiedTag.Color = color;
+        CurrentColor.Color = ModifiedTag.Color;
+    }
+
+    private void _ColorButtonClicked()
+    {
+        ColorPickerPopup.Show();
+    }
+
+    private void _ColorPickerVisibilityChanged()
+    {
+        ColorPickerButton.Disabled = ColorPickerPopup.Visible;
     }
 
     private void _OkClicked()


### PR DESCRIPTION
It's less transparent, darker, smaller and placed more nicely. Also fix Cancel changing internal TagDefinition content but not (immediately) saving it. TagEditor now uses a clone of the TagDefinition so unintended mutation is no longer a thing.

Fix #6